### PR TITLE
Add clojure template, make solve.bat pass absolute path to input file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 input/*
+.idea/*
+lib/*

--- a/clojure/Day00.clj
+++ b/clojure/Day00.clj
@@ -1,0 +1,3 @@
+(ns Day00)
+; Just prints the content of the supplied file as a demo
+(println (slurp (first *command-line-args*)))

--- a/clojure/run.bat
+++ b/clojure/run.bat
@@ -1,0 +1,3 @@
+set file_name=%1.clj
+set input_file=%2
+powershell -command clj %file_name% %2

--- a/solve.bat
+++ b/solve.bat
@@ -1,4 +1,6 @@
 @echo off
-cd %1
-if "%~3"=="" (set file_path=./input/%2.txt) else (set file_path=%3)
-run %2 %file_path%
+pushd .
+cd %~dp0
+if "%~3"=="" (set file_path="%~dp0input/%2.txt") else (set file_path="%~f3")
+popd
+%1/run %1/%2 %file_path%


### PR DESCRIPTION
Setup for clojure as well as a little addition to the solve.bat script: the input file path is now passed down as an absolute path so that the programs can use it properly.